### PR TITLE
Handle aiohttp gracefull shutdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ pytest-cov = ">=2.6.1"
 pytest-mock = ">=1.10.1"
 pytest-mockservers = ">=0.4.0"
 yarl = ">=1.3.0"
+pytest-timeout = "^1.3"
 
 [tool.poetry.extras]
 aiohttp = ["aiohttp"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,13 +22,15 @@ async def statsd_server(udp_server_factory, unused_udp_port):
 @pytest.fixture
 def wait_for():
     async def _wait_for(
-        collected: List[str], *, count: int = 1, attempts: int = 5
+        collected: List[str], *, count: int = 1, attempts: int = 50
     ) -> None:
+        sleep = 0.0
         while attempts:
             if len(collected) == count:
                 break
 
             attempts -= 1
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(sleep)
+            sleep = 0.01
 
     return _wait_for


### PR DESCRIPTION
Application hangs when `web.run_app` is used, 
due to `aiohttp` send cancel to all pending coroutines event before `close` is awaited. 

As result `self._listen_future_join.set_result(True)` will never get called.
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/web.py#L437