### PR TITLE
[fix] Make tags type a Mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.10.0 (20XX-XX-XX)
 
+- Fixed `MTags` type to be a `Mapping` to avoid common invariance type-checking errors, #14
+
 ## 0.9.0 (2019-11-29)
 
 - Added sample rate as class attribute, for setting sample rate class-wide, #11 by @aviramha

--- a/aiodogstatsd/typedefs.py
+++ b/aiodogstatsd/typedefs.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Dict, Union
+from typing import Mapping, Union
 
 __all__ = (
     "MName",
@@ -20,7 +20,7 @@ MSampleRate = Union[float, int]
 
 MTagKey = str
 MTagValue = Union[float, int, str]
-MTags = Dict[MTagKey, MTagValue]
+MTags = Mapping[MTagKey, MTagValue]
 
 
 @enum.unique


### PR DESCRIPTION
This reduces type errors when using the library. For example, consider a file `test.py` like:
```python
from aiodogstatsd import Client

tags = {"foo": "bar"}
Client(constant_tags=tags)
```

...then running mypy on it:
```
❯ mypy test.py
test.py:4: error: Argument "constant_tags" to "Client" has incompatible type "Dict[str, str]"; expected "Optional[Dict[str, Union[float, int, str]]]"
test.py:4: note: "Dict" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
test.py:4: note: Consider using "Mapping" instead, which is covariant in the value type
Found 1 error in 1 file (checked 1 source file)
```

With this change, mypy is happy. Without this change, it's necessary to annotate variables that hold tags with the `typedefs.MTags` type explicitly.