### PR TITLE
[feat] Add create_metric_task for easy timing metrics for asyncio tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog for aiodogstatsd
 
 ## 0.15.0 (20XX-XX-XX)
-
+- Added `.timeit_task()`, `asyncio.create_task` like function that sends timing metric when the task finishes, #29 by @aviramha
+- Added `threshold_ms` (Optional) to `.timeit()` for sending timing metric only when exceeds threshold, #27 by @aviramha
 ## 0.14.0 (2020-11-16)
 
 - Added Python 3.9.* support

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,9 +93,19 @@ client.timing("query.time", value=0.5)
 
 ### TimeIt
 
-Context manager for easily timing methods, optionally settings `tags` and a `sample_rate`.
+Context manager for easily timing methods, optionally settings `tags`, `sample_rate` and `threshold_ms`.
 
 ```python
 with client.timeit("query.time"):
     ...
+```
+
+### timeit_task
+
+Wrapper for `asyncio.create_task` that creates a task from a given `Awaitable` and sends timing metric of it's duration.
+
+```python
+async def do_something():
+    await asyncio.sleep(1.0)
+await client.timeit_task(do_something(), "task.time")
 ```

--- a/examples/timeit_task.py
+++ b/examples/timeit_task.py
@@ -1,0 +1,24 @@
+import asyncio
+
+import aiodogstatsd
+
+
+async def do_something():
+    await asyncio.sleep(1)
+
+
+async def main():
+    client = aiodogstatsd.Client(
+        host="0.0.0.0", port=9125, constant_tags={"whoami": "I am Batman!"}
+    )
+    await client.connect()
+
+    for _ in range(5000):
+        await client.timeit(do_something(), "task_finished")
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())


### PR DESCRIPTION
Closes #28 